### PR TITLE
Ensure that color-flame does not get overridden by deprecated value

### DIFF
--- a/color.html
+++ b/color.html
@@ -9,7 +9,11 @@
             --color-grey: #9fa4a8;
             --color-stone: #d3d6d9;
             --color-porcelain: #e9ebec;
-            --color-flame: #d95000;
+            /**
+             * Temporary important declaration to avoid conflict with
+             * deprecated style in webcomponents/kano-style
+             */
+            --color-flame: #d95000 !important;
             --color-kano-orange: #ff6900;
             --color-pumpkin: #ff860d;
             --color-cinnabar: #cf2828;


### PR DESCRIPTION
Applies when web-components styles and kwc-style are present in a project. This won't be necessary and should be removed after kano-style has been fully ported to, and replaced by, kwc-style.